### PR TITLE
Add nvidia-utils package to ensure opengl drivers are also installed

### DIFF
--- a/install-on-arch.sh
+++ b/install-on-arch.sh
@@ -30,7 +30,7 @@ case $vid in
 	;;
 
 [3])
-    DRI='nvidia nvidia-settings'
+    DRI='nvidia nvidia-settings nvidia-utils'
     ;;
 
 [4])


### PR DESCRIPTION
In my previous commit I added the nvidia drivers however it seems that those don't include the OpenGL drivers. They'd be required to install things like steam later on. The nvidia-utils package will install OpenGL drivers.﻿
