### PR TITLE
fix logout

### DIFF
--- a/bin/powermenu.sh
+++ b/bin/powermenu.sh
@@ -97,7 +97,7 @@ case $chosen in
     $logout)
 		ans=$(confirm_exit &)
 		if [[ $ans == "yes" || $ans == "YES" || $ans == "y" || $ans == "Y" ]]; then
-			killall xmonad;
+			pkill -9 xmonad;
 		elif [[ $ans == "no" || $ans == "NO" || $ans == "n" || $ans == "N" ]]; then
 			exit 0
         else


### PR DESCRIPTION
the logout doesn't work for me 'cause it says "no xmonad processes found"
but if you use `pkill` it works and you get back to the DM.