### PR TITLE
changed getram scripts to use en_US.UTF-8 as locale for numbers

### DIFF
--- a/config/eww-1366/scripts/getram
+++ b/config/eww-1366/scripts/getram
@@ -1,2 +1,2 @@
 #!/bin/bash
-printf "%.0f\n" $(free -m | grep Mem | awk '{print ($3/$2)*100}')
+LC_NUMERIC="en_US.UTF-8" printf "%.0f\n" $(free -m | grep Mem | awk '{print ($3/$2)*100}')

--- a/config/eww-1920/scripts/getram
+++ b/config/eww-1920/scripts/getram
@@ -1,2 +1,2 @@
 #!/bin/bash
-printf "%.0f\n" $(free -m | grep Mem | awk '{print ($3/$2)*100}')
+LC_NUMERIC="en_US.UTF-8" printf "%.0f\n" $(free -m | grep Mem | awk '{print ($3/$2)*100}')


### PR DESCRIPTION
Depending on the settings of your PC this line with printf could return `invalid number` because a decimal fraction is not always represented with a `.` but with a `,` instead.
Putting `LC_NUMERIC="en_US.UTF-8"` sets the locale for numbers to en_US.UTF-8 (which uses the `.` of course) for the script only. 

See also https://stackoverflow.com/questions/12845997/printf-command-inside-a-script-returns-invalid-number